### PR TITLE
More thorough destruction and limiting loopback to Chrome only

### DIFF
--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -440,7 +440,6 @@ export class User extends Collider {
       );
       return;
     }
-    console.log("got texture", texture, this.gradientTextureName, t.catalog);
     this.texture = texture;
     this.textureType = TextureType.Default;
   }

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -283,29 +283,27 @@ export class User extends Collider {
       },
     });
     texture.onError = (e) => this.textureError(e);
+
     let textureMask: PIXI.Rectangle = null;
     const resource = texture.resource;
+
     let x = 0;
     let y = 0;
     let size = baseSize;
-    let height = baseSize;
     const aspect = resource.width / resource.height;
     if (aspect > 1) {
       x = resource.width / 2 - resource.height / 2;
       size = resource.height;
     } else if (aspect > 1) {
-      const hh = resource.height / 2;
       y = resource.height / 2 - resource.width / 2;
       size = resource.width;
     } else {
       texture.setSize(baseSize, baseSize);
     }
     textureMask = new PIXI.Rectangle(x, y, size, size);
-
     this.texture = new PIXI.Texture(texture, textureMask);
     this.texture.update();
-    this.width = baseSize;
-    this.height = baseSize;
+    this.tryUpdateNameGraphics();
   }
 
   private textureError(err: ErrorEvent) {
@@ -442,6 +440,7 @@ export class User extends Collider {
     }
     this.texture = texture;
     this.textureType = TextureType.Default;
+    this.tryUpdateNameGraphics();
   }
 
   private async proximityUpdate(other: User) {
@@ -578,9 +577,6 @@ export class User extends Collider {
 
   // createNameGraphics creates a Text graphics object which
   // shows the user's name at the bottom of their tile.
-  // TODO: for Firefox users, the size and positioning of
-  // the text becomes offset. This is a known issue which
-  // we aim to produce a followup fix for.
   private createNameGraphics() {
     const name = "nameGraphics";
     const existing = this.getChildByName(name);
@@ -604,5 +600,16 @@ export class User extends Collider {
 
     this.addChild(txt);
     this.nameGraphics = txt;
+  }
+
+  private tryUpdateNameGraphics() {
+    if (!this.nameGraphics) return;
+
+    const sx = 1 * (1 / this.scale.x);
+    const sy = 1 * (1 / this.scale.y);
+    const bounds = this.staticBounds;
+    this.nameGraphics.position.x = (bounds.x + bounds.width / 2) * sx;
+    this.nameGraphics.position.y = (bounds.y + bounds.height - 8) * sy;
+    this.nameGraphics.scale.set(sx, sy);
   }
 }

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -99,6 +99,7 @@ export class User extends Collider {
   }
 
   destroy() {
+    console.log("destroying user", this.id);
     this.media.leaveZone();
     this.media.leaveBroadcast();
     this.media.destroy();
@@ -488,6 +489,7 @@ export class User extends Collider {
   // If the video is resized, we will need to recalcualte
   // the texture dimensions and mask.
   private videoTextureResized(e: UIEvent) {
+    console.log("resized");
     if (this.textureType === TextureType.Video) {
       this.setVideoTexture(true);
     }

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -489,7 +489,6 @@ export class User extends Collider {
   // If the video is resized, we will need to recalcualte
   // the texture dimensions and mask.
   private videoTextureResized(e: UIEvent) {
-    console.log("resized");
     if (this.textureType === TextureType.Video) {
       this.setVideoTexture(true);
     }

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -104,8 +104,20 @@ export class User extends Collider {
     this.media.leaveBroadcast();
     this.media.destroy();
     delete this.media;
-
-    super.destroy(true);
+    // If this is a local user or current texture is video,
+    // destroy texture and all children.
+    if (this.isLocal || this.textureType === TextureType.Video) {
+      super.destroy(true);
+      return;
+    }
+    // If the current texture is the default texture,
+    // do not destroy it. It will be needed by other
+    // users.
+    super.destroy({
+      children: true,
+      texture: false,
+      baseTexture: false,
+    });
   }
 
   // updateTracks sets the tracks, but does not
@@ -428,7 +440,7 @@ export class User extends Collider {
       );
       return;
     }
-
+    console.log("got texture", texture, this.gradientTextureName, t.catalog);
     this.texture = texture;
     this.textureType = TextureType.Default;
   }

--- a/src/models/userMedia.ts
+++ b/src/models/userMedia.ts
@@ -20,6 +20,9 @@ export enum Action {
   Broadcasting,
 }
 
+const isChrome: boolean = !!(navigator.userAgent.indexOf("Chrome") !== -1);
+console.log("IsChrome", isChrome);
+
 // UserMedia holds all audio and video related tags,
 // streams, and panners for a user.
 export class UserMedia {
@@ -312,14 +315,21 @@ export class UserMedia {
     this.stereoPannerNode.connect(compressor);
     compressor.connect(destination);
 
+    let srcStream: MediaStream;
+
     // This is a workaround for there being no noise cancellation
-    // when using Web Audio API in Chromium (another bug):
+    // when using Web Audio API in Chrome (another bug):
     // https://bugs.chromium.org/p/chromium/issues/detail?id=687574
-    this.loopback = new Loopback();
-    await this.loopback.start(destination.stream);
-    const loopbackStream = this.loopback.getLoopback();
+    if (isChrome) {
+      this.loopback = new Loopback();
+      await this.loopback.start(destination.stream);
+      srcStream = this.loopback.getLoopback();
+    } else {
+      srcStream = destination.stream;
+    }
+
     this.audioTag.muted = false;
-    this.audioTag.srcObject = loopbackStream;
+    this.audioTag.srcObject = srcStream;
     this.audioTag.play();
   }
 

--- a/src/models/userMedia.ts
+++ b/src/models/userMedia.ts
@@ -272,8 +272,16 @@ export class UserMedia {
   }
 
   destroy() {
+    console.log("destroying media", this.id);
     this.loopback?.destroy();
     delete this.loopback;
+    this.audioTag?.remove();
+    this.videoTag.oncanplay = null;
+    this.videoTag.onresize = null;
+    this.videoTag.onplaying = null;
+    this.videoTag.onended = null;
+    this.videoTag.onpause = null;
+    this.videoTag.remove();
   }
 
   private async createAudioNodes(gainValue: number, panValue: number) {

--- a/src/models/userMedia.ts
+++ b/src/models/userMedia.ts
@@ -193,7 +193,7 @@ export class UserMedia {
     console.log("resetting audio nodes");
     const gain = this.gainNode?.gain?.value;
     const pan = this.stereoPannerNode?.pan?.value;
-  
+
     this.gainNode = null;
     this.stereoPannerNode = null;
     this.loopback?.destroy();

--- a/src/models/userMedia.ts
+++ b/src/models/userMedia.ts
@@ -109,7 +109,6 @@ export class UserMedia {
     const video = document.createElement("video");
 
     video.oncanplay = () => {
-      console.log("can play", this.userName);
       if (!this.videoPlaying) {
         video.play().catch((err) => {
           console.log("failed to play after oncanplay event: ", err);
@@ -191,8 +190,17 @@ export class UserMedia {
     this.audioTrack = newTrack;
 
     // Reset nodes
+    console.log("resetting audio nodes");
+    const gain = this.gainNode.gain.value;
+    const pan = this.stereoPannerNode.pan.value;
+  
     this.gainNode = null;
     this.stereoPannerNode = null;
+    this.loopback?.destroy();
+    this.loopback = null;
+
+    // Recreate audio nodes with previous gain and pan
+    this.createAudioNodes(gain, pan);
 
     if (this.currentAction === Action.InZone) {
       this.showOrUpdateZonemate();

--- a/src/models/userMedia.ts
+++ b/src/models/userMedia.ts
@@ -191,8 +191,8 @@ export class UserMedia {
 
     // Reset nodes
     console.log("resetting audio nodes");
-    const gain = this.gainNode.gain.value;
-    const pan = this.stereoPannerNode.pan.value;
+    const gain = this.gainNode?.gain?.value;
+    const pan = this.stereoPannerNode?.pan?.value;
   
     this.gainNode = null;
     this.stereoPannerNode = null;
@@ -200,7 +200,9 @@ export class UserMedia {
     this.loopback = null;
 
     // Recreate audio nodes with previous gain and pan
-    this.createAudioNodes(gain, pan);
+    if (gain && pan) {
+      this.createAudioNodes(gain, pan);
+    }
 
     if (this.currentAction === Action.InZone) {
       this.showOrUpdateZonemate();

--- a/src/room.ts
+++ b/src/room.ts
@@ -5,7 +5,6 @@ import {
   DailyEventObjectParticipant,
   DailyParticipant,
   DailyEventObjectFatalError,
-  DailyEventObjectNoPayload,
   DailyEventObjectCameraError,
   DailyEventObjectParticipants,
   DailyEventObjectNetworkConnectionEvent,

--- a/src/util/loopback.ts
+++ b/src/util/loopback.ts
@@ -46,6 +46,9 @@ export class Loopback {
   }
 
   public destroy() {
+    this.peer1.ontrack = null;
+    this.peer1.onicecandidate = null;
+    this.peer2.ontrack = null;
     this.peer1.close();
     this.peer2.close();
   }

--- a/src/world.ts
+++ b/src/world.ts
@@ -516,6 +516,7 @@ export class World {
 
   destroy() {
     Textures.destroy();
+    this.localUser = null;
     this.furniture = [];
     this.robots = [];
     this.app.destroy(true, true);


### PR DESCRIPTION
This commit adds more thorough destruction when leaving a call, which I noticed was lacking when writing the content. This is to avoid leaving unneeded DOM elements and dangling event handlers. 

It also limits our loopback workaround for echo cancellation only to the browser that is affected by this issue: Chrome. This allows panning to still work in other browsers.

It also fixes the issue we saw with name tags in Firefox-originating sprites being of the wrong size and position.