### PR TITLE
Demo cleanup, commenting, refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This demo shows one way to implement a video and audio call application with gamified spatialization elements using [Daily's call object](https://docs.daily.co/guides/products/call-object).
 
+You can find a [tutorial series based on this demo](https://www.daily.co/blog/tag/spatialization/) on the Daily blog.
+
 ![Spatial video demo showing 2D world elements](./screenshot.png)
 
 ## Getting set up with Daily

--- a/src/models/spot.ts
+++ b/src/models/spot.ts
@@ -1,5 +1,4 @@
 import * as PIXI from "pixi.js";
-import { DisplayObject } from "pixi.js";
 import { Textures } from "../textures";
 import { Pos, Size } from "../worldTypes";
 

--- a/src/models/tests/user.test.ts
+++ b/src/models/tests/user.test.ts
@@ -89,7 +89,9 @@ describe("User panner tests", () => {
     expect(pannerMod.pan).toBe(wantPan);
 
     local.processUsers([remote]);
-    expect(remote.media.stereoPannerNode.pan.value).toBe(wantPan);
+
+    const nodeChain = remote.media["nodeChain"];
+    expect(nodeChain.getPan()).toBe(wantPan);
   });
 
   test("Pan: speaker on the max left of listener", () => {
@@ -107,7 +109,9 @@ describe("User panner tests", () => {
     expect(pannerMod.pan).toBe(wantPan);
 
     local.processUsers([remote]);
-    expect(remote.media.stereoPannerNode.pan.value).toBe(wantPan);
+
+    const nodeChain = remote.media["nodeChain"];
+    expect(nodeChain.getPan()).toBe(wantPan);
   });
 
   test("Pan: speaker on the partial right of listener", () => {
@@ -124,7 +128,8 @@ describe("User panner tests", () => {
     expect(pannerMod.pan).toBe(0.5);
 
     local.processUsers([remote]);
-    expect(remote.media.stereoPannerNode.pan.value).toBe(0.5);
+    const nodeChain = remote.media["nodeChain"];
+    expect(nodeChain.getPan()).toBe(0.5);
   });
 
   test("Pan: speaker on the partial left of listener", () => {
@@ -141,7 +146,8 @@ describe("User panner tests", () => {
     expect(pannerMod.pan).toBe(-0.5);
 
     local.processUsers([remote]);
-    expect(remote.media.stereoPannerNode.pan.value).toBe(-0.5);
+    const nodeChain = remote.media["nodeChain"];
+    expect(nodeChain.getPan()).toBe(-0.5);
   });
 
   test("Pan: speaker in the center of the listener", () => {
@@ -158,7 +164,8 @@ describe("User panner tests", () => {
     expect(pannerMod.pan).toBe(0);
 
     local.processUsers([remote]);
-    expect(remote.media.stereoPannerNode.pan.value).toBe(0);
+    const nodeChain = remote.media["nodeChain"];
+    expect(nodeChain.getPan()).toBe(0);
   });
 });
 

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -156,6 +156,9 @@ export class User extends Collider {
     }
 
     if (zoneID === broadcastZoneID) {
+      if (this.media.currentAction === Action.InZone) {
+        this.media.leaveZone();
+      }
       this.alpha = maxAlpha;
       this.media.enterBroadcast();
     }
@@ -209,7 +212,7 @@ export class User extends Collider {
     return this.localZoneMates;
   }
 
-  moveTo(pos: Pos, trial = false) {
+  moveTo(pos: Pos) {
     this.x = Math.round(pos.x);
     this.y = Math.round(pos.y);
     this.getBounds();

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -327,7 +327,7 @@ export class User extends Collider {
   }
 
   private async processUser(o: User) {
-    // If this is the local user, skip
+    // If this is the local user verify texture and skip
     if (o.id === this.id) {
       if (this.textureType === TextureType.Unknown) {
         this.setDefaultTexture();

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -169,7 +169,9 @@ export class User extends Collider {
       }
       if (this.onJoinZone) this.onJoinZone({ zoneID: zoneID, spotID: spotID });
       if (zoneID === globalZoneID) {
-        this.setVideoTexture();
+        if (!this.media.cameraDisabled) {
+          this.setVideoTexture();
+        }
         this.media.leaveZone();
         return;
       }
@@ -439,11 +441,6 @@ export class User extends Collider {
     if (this.textureType === TextureType.Video) {
       this.texture.destroy();
     }
-
-    // I am not (yet) sure why this is needed, but without
-    // it we get inconsistent bounds and broken collision
-    // detection when switching textures.
-    this.getBounds(true);
 
     const t = Textures.get();
     const texture = t.catalog[this.gradientTextureName];

--- a/src/models/userMedia.ts
+++ b/src/models/userMedia.ts
@@ -318,8 +318,6 @@ export class UserMedia {
     }
   }
 
-  destroyNodeChain() {}
-
   muteAudio() {
     if (!this.audioTag.muted) {
       this.audioTag.muted = true;

--- a/src/models/userMedia.ts
+++ b/src/models/userMedia.ts
@@ -1,7 +1,11 @@
+import { TilingSprite } from "pixi.js";
 import {
-  StereoPannerNode,
   AudioContext,
-  GainNode,
+  IMediaStreamAudioDestinationNode,
+  IGainNode,
+  IStereoPannerNode,
+  IDynamicsCompressorNode,
+  IMediaStreamAudioSourceNode,
 } from "standardized-audio-context";
 import { standardTileSize } from "../config";
 import { Loopback } from "../util/loopback";
@@ -23,28 +27,119 @@ export enum Action {
 const isChrome: boolean = !!(navigator.userAgent.indexOf("Chrome") !== -1);
 console.log("IsChrome", isChrome);
 
+// NodeChain is responsible for creating, destroying, and connecting our
+// Web Audio API nodes.
+class NodeChain {
+  initialized: boolean;
+
+  private source: IMediaStreamAudioSourceNode<AudioContext>;
+  private destination: IMediaStreamAudioDestinationNode<AudioContext>;
+  private gain: IGainNode<AudioContext>;
+  private stereoPanner: IStereoPannerNode<AudioContext>;
+  private compressor: IDynamicsCompressorNode<AudioContext>;
+  private loopback: Loopback;
+
+  getGain(): number {
+    return this.gain?.gain.value;
+  }
+
+  updateGain(val: number) {
+    if (this.gain.gain.value === val) return;
+    try {
+      this.gain.gain.setValueAtTime(val, window.audioContext.currentTime);
+    } catch (e) {
+      console.error(`failed to update gain: ${e} (gain value: ${val})`);
+    }
+  }
+
+  getPan(): number {
+    return this.stereoPanner?.pan.value;
+  }
+
+  updatePan(val: number) {
+    if (this.stereoPanner.pan.value === val) return;
+    try {
+      this.stereoPanner.pan.setValueAtTime(
+        val,
+        window.audioContext.currentTime
+      );
+    } catch (e) {
+      console.error(`failed to update pan: ${e} (pan value: ${val})`);
+    }
+  }
+
+  async init(track: MediaStreamTrack): Promise<MediaStream> {
+    const stream = new MediaStream([track]);
+
+    this.gain = window.audioContext.createGain();
+    this.stereoPanner = window.audioContext.createStereoPanner();
+    this.compressor = window.audioContext.createDynamicsCompressor();
+    this.source = window.audioContext.createMediaStreamSource(stream);
+    this.destination = window.audioContext.createMediaStreamDestination();
+
+    // Apparently this is required due to a Chromium bug!
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=933677
+    // https://stackoverflow.com/questions/55703316/audio-from-rtcpeerconnection-is-not-audible-after-processing-in-audiocontext
+    const mutedAudio = new Audio();
+    mutedAudio.muted = true;
+    mutedAudio.srcObject = stream;
+    mutedAudio.play();
+
+    this.source.connect(this.gain);
+    this.gain.connect(this.stereoPanner);
+    this.stereoPanner.connect(this.compressor);
+    this.compressor.connect(this.destination);
+
+    let srcStream: MediaStream;
+
+    // This is a workaround for there being no noise cancellation
+    // when using Web Audio API in Chrome (another bug):
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=687574
+    if (isChrome) {
+      this.loopback = new Loopback();
+      await this.loopback.start(this.destination.stream);
+      srcStream = this.loopback.getLoopback();
+    } else {
+      srcStream = this.destination.stream;
+    }
+    this.initialized = true;
+    return srcStream;
+  }
+
+  destroy() {
+    if (!this.initialized) return;
+    this.initialized = false;
+    this.source.disconnect();
+    this.destination.disconnect();
+    this.gain.disconnect();
+    this.stereoPanner.disconnect();
+    this.compressor.disconnect();
+    this.loopback?.destroy();
+    this.source = null;
+    this.destination = null;
+    this.gain = null;
+    this.stereoPanner = null;
+    this.compressor = null;
+    this.loopback = null;
+  }
+}
+
 // UserMedia holds all audio and video related tags,
 // streams, and panners for a user.
 export class UserMedia {
+  videoTag: HTMLVideoElement;
+  audioTag: HTMLAudioElement;
+  cameraDisabled: boolean;
+  currentAction: Action = Action.Traversing;
+  userName: string;
+  videoDelayedPlayHandler: () => void;
+
+
   private videoTrack: MediaStreamTrack;
   private audioTrack: MediaStreamTrack;
   private _videoPlaying = false;
-
-  videoTag: HTMLVideoElement;
-  audioTag: HTMLAudioElement;
-
-  videoDelayedPlayHandler: () => void;
-
-  cameraDisabled: boolean;
-  tileDisabled: boolean;
-
-  gainNode: GainNode<AudioContext>;
-  stereoPannerNode: StereoPannerNode<AudioContext>;
-
-  currentAction: Action = Action.Traversing;
-  id: string;
-  userName: string;
-  loopback: Loopback;
+  private nodeChain: NodeChain = new NodeChain();
+  private id: string;
 
   constructor(id: string, userName: string, isLocal: boolean) {
     this.id = id;
@@ -98,7 +193,6 @@ export class UserMedia {
 
   private async registerPlay() {
     while (this.videoTag.currentTime === 0) {
-      console.log("still waiting for timestamp: ", this.videoTag.currentTime);
       await new Promise((r) => setTimeout(r, 10));
     }
     this.videoPlaying = true;
@@ -153,6 +247,10 @@ export class UserMedia {
 
   updateVideoSource(newTrack: MediaStreamTrack) {
     if (!newTrack) {
+      // If the update was called with no valid video track,
+      // we take that as the camera being disabled. If the user
+      // is in a focus zone or broadcasting, update their
+      // focus tiles accordingly.
       this.cameraDisabled = true;
       if (this.currentAction === Action.InZone) {
         this.showOrUpdateZonemate();
@@ -163,12 +261,17 @@ export class UserMedia {
       }
       return;
     }
+    // If there is a valid video track, we know the camera
+    // is not disabled.
     this.cameraDisabled = false;
+    // Only replace the track if the track ID has changed.
     if (newTrack.id !== this.videoTrack?.id) {
       this.videoTrack = newTrack;
       this.videoTag.srcObject = new MediaStream([newTrack]);
     }
 
+    // If the user is in a focus zone or broadcasting,
+    // update their focus tiles accordingly.
     if (this.currentAction === Action.InZone) {
       this.showOrUpdateZonemate();
       return;
@@ -179,25 +282,21 @@ export class UserMedia {
   }
 
   updateAudioSource(newTrack: MediaStreamTrack) {
-    if (!this.audioTag) return;
-    if (!newTrack) {
-      return;
-    }
+    if (!this.audioTag || !newTrack) return;
 
     if (newTrack.id === this.audioTrack?.id) {
       return;
     }
+
     this.audioTrack = newTrack;
 
-    // Reset nodes
-    console.log("resetting audio nodes");
-    const gain = this.gainNode?.gain?.value;
-    const pan = this.stereoPannerNode?.pan?.value;
+    // The track has changed, so reset the nodes.
 
-    this.gainNode = null;
-    this.stereoPannerNode = null;
-    this.loopback?.destroy();
-    this.loopback = null;
+    // Save current gain and pan values, if any.
+    const gain = this.nodeChain?.getGain();
+    const pan = this.nodeChain?.getPan();
+
+    this.nodeChain.destroy();
 
     // Recreate audio nodes with previous gain and pan
     if (gain && pan) {
@@ -212,6 +311,8 @@ export class UserMedia {
       this.showOrUpdateBroadcast();
     }
   }
+
+  destroyNodeChain() {}
 
   muteAudio() {
     if (!this.audioTag.muted) {
@@ -256,38 +357,18 @@ export class UserMedia {
 
   updateAudio(gainValue: number, panValue: number) {
     if (!this.audioTag || !this.audioTrack) return;
-    if (!this.gainNode) {
+
+    if (!this.nodeChain.initialized) {
       this.createAudioNodes(gainValue, panValue);
-      return;
     }
 
-    if (this.gainNode.gain.value != gainValue) {
-      try {
-        this.gainNode.gain.setValueAtTime(
-          gainValue,
-          window.audioContext.currentTime
-        );
-      } catch (e) {
-        console.error(`failed to update gain: ${e} (gain value: ${gainValue})`);
-      }
-    }
-
-    if (this.stereoPannerNode.pan.value != panValue) {
-      try {
-        this.stereoPannerNode.pan.setValueAtTime(
-          panValue,
-          window.audioContext.currentTime
-        );
-      } catch (e) {
-        console.error(`failed to update pan: ${e} (pan value: ${panValue})`);
-      }
-    }
+    this.nodeChain.updateGain(gainValue);
+    this.nodeChain.updatePan(panValue);
   }
 
   destroy() {
     console.log("destroying media", this.id);
-    this.loopback?.destroy();
-    delete this.loopback;
+    this.nodeChain.destroy();
     this.audioTag?.remove();
     this.videoTag.oncanplay = null;
     this.videoTag.onresize = null;
@@ -298,48 +379,12 @@ export class UserMedia {
   }
 
   private async createAudioNodes(gainValue: number, panValue: number) {
-    const stream = new MediaStream([this.audioTrack]);
-
-    this.gainNode = window.audioContext.createGain();
-    this.gainNode.gain.value = gainValue;
-
-    this.stereoPannerNode = window.audioContext.createStereoPanner();
-
-    this.stereoPannerNode.pan.value = panValue;
-
-    const compressor = window.audioContext.createDynamicsCompressor();
-
-    const source = window.audioContext.createMediaStreamSource(stream);
-    const destination = window.audioContext.createMediaStreamDestination();
-
-    // Apparently this is required due to a Chromium bug!
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=933677
-    // https://stackoverflow.com/questions/55703316/audio-from-rtcpeerconnection-is-not-audible-after-processing-in-audiocontext
-    const mutedAudio = new Audio();
-    mutedAudio.muted = true;
-    mutedAudio.srcObject = stream;
-    mutedAudio.play();
-
-    source.connect(this.gainNode);
-    this.gainNode.connect(this.stereoPannerNode);
-    this.stereoPannerNode.connect(compressor);
-    compressor.connect(destination);
-
-    let srcStream: MediaStream;
-
-    // This is a workaround for there being no noise cancellation
-    // when using Web Audio API in Chrome (another bug):
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=687574
-    if (isChrome) {
-      this.loopback = new Loopback();
-      await this.loopback.start(destination.stream);
-      srcStream = this.loopback.getLoopback();
-    } else {
-      srcStream = destination.stream;
-    }
+    const stream = await this.nodeChain.init(this.audioTrack);
+    this.nodeChain.updateGain(gainValue);
+    this.nodeChain.updatePan(panValue);
 
     this.audioTag.muted = false;
-    this.audioTag.srcObject = srcStream;
+    this.audioTag.srcObject = stream;
     this.audioTag.play();
   }
 

--- a/src/room.ts
+++ b/src/room.ts
@@ -131,7 +131,6 @@ export class Room {
   private setBandwidth(level: BandwidthLevel) {
     switch (level) {
       case BandwidthLevel.Tile:
-        console.log("setting bandwidth to tile");
         this.localBandwidthLevel = level;
         this.callObject.setBandwidth({
           trackConstraints: {
@@ -142,7 +141,6 @@ export class Room {
         });
         break;
       case BandwidthLevel.Focus:
-        console.log("setting bandwidth to focus");
         this.localBandwidthLevel = level;
         this.callObject.setBandwidth({
           trackConstraints: {

--- a/src/util/tile.ts
+++ b/src/util/tile.ts
@@ -44,14 +44,19 @@ export function showZonemate(
   if (!zonemate) {
     zonemate = createZonemate(sessionID, name);
   }
-  const tracks: Array<MediaStreamTrack> = [];
-  if (videoTrack) tracks.push(videoTrack);
-  if (audioTrack) tracks.push(audioTrack);
-  if (tracks.length === 0) return;
 
   const vid = <HTMLVideoElement>(
     document.getElementById(getVideoTagID(sessionID))
   );
+
+  const tracks: Array<MediaStreamTrack> = [];
+  if (videoTrack) tracks.push(videoTrack);
+  if (audioTrack) tracks.push(audioTrack);
+  if (tracks.length === 0) {
+    vid.srcObject = null;
+    return;
+  }
+
   vid.srcObject = new MediaStream(tracks);
 }
 

--- a/src/world.ts
+++ b/src/world.ts
@@ -464,7 +464,7 @@ export class World {
       newX += s;
     });
 
-    // If no keys were pressed, the coordintates remain
+    // If no keys were pressed, the coordinates remain
     // identical. Early out, nothing more to do.
     if (newX === currentPos.x && newY === currentPos.y) {
       return;

--- a/src/world.ts
+++ b/src/world.ts
@@ -168,7 +168,7 @@ export class World {
 
   initRemoteParticpant(sessionID: string, userName: string) {
     // User may have been created as part of an out of order
-    // update. If it already exists, just update the name
+    // update.
     let user = this.getUser(sessionID);
     if (!user) {
       user = this.createUser(sessionID, -10000, -10000, userName);
@@ -189,7 +189,7 @@ export class World {
     const worldCenter = defaultWorldSize / 2;
 
     // These position constraints are largely arbitrary;
-    // I just felt with what spawning area "feels" right.
+    // I just went with what spawning area "feels" right.
     const p = {
       x: rand(worldCenter - 300, worldCenter + 300),
       y: rand(worldCenter - 250, worldCenter + 250),

--- a/src/world.ts
+++ b/src/world.ts
@@ -171,9 +171,8 @@ export class World {
     // update. If it already exists, just update the name
     let user = this.getUser(sessionID);
     if (!user) {
-      user = this.createUser(sessionID, -10000, -1000, userName);
+      user = this.createUser(sessionID, -10000, -10000, userName);
     }
-    user.setUserName(userName);
   }
 
   updateParticipantPos(sessionID: string, posX: number, posY: number) {
@@ -360,9 +359,9 @@ export class World {
       userName,
       x,
       y,
-      (isLocal = isLocal),
-      (onEnterVicinity = onEnterVicinity),
-      (onLeaveVicinity = onLeaveVicinity),
+      isLocal,
+      onEnterVicinity,
+      onLeaveVicinity,
       onJoinZone
     );
     this.usersContainer.addChild(user);


### PR DESCRIPTION
This PR contains some cleanup and edge case fixes I noticed while writing the third piece of content. It also contains a little bit of refactoring of the userMedia file to make it easier to write about (and hopefully read). Overview (I also left some comments in the actual code below to give a better idea of what's changing):

* More comments (partly used in content, thought it might be worth keeping them in the code as well)
* Removal of some unneeded imports
* More reliable zone leaving if moving from desk zone straight to broadcast zone
* If local user is moving to global zone, only try to set their texture back to video if their camera is enabled
* Remove unused parameter in `moveTo()` method.
* Remove some no longer needed calls to `getBounds()`
* If setting a default texture and current texture is video, destroy video texture
* Move audio graph to dedicated `NodeChain` class, keeping `UserMedia` less cluttered and making the graph logic more readable
* More reliable audio graph destruction