### PR TITLE
More tidy, better texture destruction

### DIFF
--- a/src/models/collider.ts
+++ b/src/models/collider.ts
@@ -7,7 +7,7 @@ export interface ICollider {
   hits: (other: ICollider) => boolean;
 }
 
-export interface IInteractable {
+export interface IInteractable extends ICollider {
   tryInteract: (user: User) => void;
 }
 

--- a/src/models/robot.ts
+++ b/src/models/robot.ts
@@ -1,9 +1,7 @@
 import { rand } from "../util/math";
 import { Pos } from "../worldTypes";
-import { BroadcastZone } from "./broadcastZone";
-import { ICollider } from "./collider";
+import { IInteractable } from "./collider";
 import { User } from "./user";
-import { DeskZone } from "./deskZone";
 
 export enum RobotRole {
   World = 0,
@@ -54,19 +52,9 @@ export class Robot extends User {
   // "Furniture" can be any non-user colliders in the world.
   // Eg: desks or broadcast spots. This overrides the user
   // furniture check.
-  checkFurnitures(others: Array<ICollider>) {
+  checkFurnitures(others: Array<IInteractable>) {
     for (let other of others) {
-      if (other instanceof BroadcastZone) {
-        const o = <BroadcastZone>other;
-        if (o) o.tryInteract(this);
-        continue;
-      }
-
-      if (other instanceof DeskZone) {
-        const o = <DeskZone>other;
-        if (o) o.tryInteract(this);
-        continue;
-      }
+      other.tryInteract(this);
     }
   }
 

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,11 +1,10 @@
-import { Collider, ICollider } from "./collider";
+import { Collider, ICollider, IInteractable } from "./collider";
 import * as PIXI from "pixi.js";
 import { DisplayObject, MIPMAP_MODES } from "pixi.js";
 import { BroadcastZone } from "./broadcastZone";
 import { Action, UserMedia } from "./userMedia";
 import { Pos, Size, ZoneData } from "../worldTypes";
 import { Textures } from "../textures";
-import { DeskZone } from "./deskZone";
 import { broadcastZoneID, globalZoneID, standardTileSize } from "../config";
 import { clamp } from "../util/math";
 
@@ -239,7 +238,7 @@ export class User extends Collider {
 
   // "Furniture" can be any non-user colliders in the world.
   // Eg: desks or broadcast spots
-  checkFurnitures(others: Array<ICollider>) {
+  checkFurnitures(others: Array<IInteractable>) {
     for (let other of others) {
       this.checkFurniture(other);
     }
@@ -404,17 +403,8 @@ export class User extends Collider {
     }
   }
 
-  private async checkFurniture(other: ICollider) {
-    if (other instanceof BroadcastZone) {
-      const o = <BroadcastZone>other;
-      if (o) o.tryInteract(this);
-      return;
-    }
-
-    if (other instanceof DeskZone) {
-      const o = <DeskZone>other;
-      if (o) o.tryInteract(this);
-    }
+  private async checkFurniture(other: IInteractable) {
+    other.tryInteract(this);
   }
 
   private streamVideo(newTrack: MediaStreamTrack) {
@@ -439,7 +429,7 @@ export class User extends Collider {
     if (this.textureType === TextureType.Default) return;
 
     if (this.textureType === TextureType.Video) {
-      this.texture.destroy();
+      this.texture?.baseTexture?.destroy();
     }
 
     const t = Textures.get();
@@ -514,7 +504,7 @@ export class User extends Collider {
     other.setDefaultTexture();
   }
 
-  // If the video is resized, we will need to recalcualte
+  // If the video is resized, we will need to recalculate
   // the texture dimensions and mask.
   private videoTextureResized(e: UIEvent) {
     if (this.textureType === TextureType.Video) {
@@ -566,14 +556,14 @@ export class User extends Collider {
     const cont = new PIXI.Container();
     cont.x = 0;
     cont.y = 0;
-    cont.width = this.width;
-    cont.height = this.height;
+    cont.width = baseSize;
+    cont.height = baseSize;
 
     const graphics = new PIXI.Graphics();
     graphics.beginFill(0x1f2d3d, 1);
     graphics.lineStyle(1, 0x121a24, 1);
 
-    graphics.drawRoundedRect(0, 0, this.width, this.height, 3);
+    graphics.drawRoundedRect(0, 0, baseSize, baseSize, 3);
     graphics.endFill();
     cont.addChild(graphics);
 

--- a/src/room.ts
+++ b/src/room.ts
@@ -183,12 +183,6 @@ export class Room {
 
     // Get the local participant
     const p = event.participants["local"];
-    console.log(
-      "JOINED MEETING. session ID, pID",
-      p.session_id,
-      p.user_id,
-      this
-    );
 
     // Retrieve the video and audio tracks of this participant
     const tracks = this.getParticipantTracks(p);

--- a/src/world.ts
+++ b/src/world.ts
@@ -6,7 +6,7 @@ import { rand } from "./util/math";
 import Floor from "./models/floor";
 import { BroadcastZone } from "./models/broadcastZone";
 import { IAudioContext, AudioContext } from "standardized-audio-context";
-import { ICollider } from "./models/collider";
+import { ICollider, IInteractable } from "./models/collider";
 import { Robot, RobotRole } from "./models/robot";
 import { Pos, ZoneData } from "./worldTypes";
 import { Textures } from "./textures";
@@ -36,7 +36,7 @@ export class World {
   private furnitureContainer: PIXI.Container = null;
 
   private robots: Array<Robot> = [];
-  private furniture: Array<ICollider> = [];
+  private furniture: Array<IInteractable> = [];
 
   constructor() {
     const w = document.getElementById("world");

--- a/style.css
+++ b/style.css
@@ -217,7 +217,6 @@ body {
 
 #world {
   display: block;
-  z-index: 1;
   width: 100%;
   height: 100%;
 }


### PR DESCRIPTION
This PR:

* Removes some unneeded imports
* Updates `IInteractable` to extend `ICollider`, which also allows us to simplify furniture interaction checks
* When destroying video texture, destroy not just the texture but the _base_ texture to ensure underlying data is properly cleared.