### PR TITLE
Refactoring for clarity, additional comments, edge case fix

### DIFF
--- a/src/models/broadcastZone.ts
+++ b/src/models/broadcastZone.ts
@@ -2,20 +2,22 @@ import * as PIXI from "pixi.js";
 import { globalZoneID, standardTileSize } from "../config";
 import { Pos } from "../worldTypes";
 
-import { Collider, doesCollide, ICollider, IInteractable } from "./collider";
+import { Collider, doesCollide } from "./collider";
 import { Spot } from "./spot";
 import { User } from "./user";
+import { IZone } from "./zone";
 
 const spotSize = standardTileSize;
 
 // BroadcastZone is a location from which any user
 // can broadcast to all other users in the world regardless
 // of proximity or zone.
-export class BroadcastZone extends PIXI.Container implements IInteractable {
-  id: number;
+export class BroadcastZone extends PIXI.Container implements IZone {
   name: string;
   physics: false;
-  spot: Spot;
+
+  private id: number;
+  private spot: Spot;
 
   constructor(id: number, x: number, y: number) {
     super();
@@ -38,12 +40,16 @@ export class BroadcastZone extends PIXI.Container implements IInteractable {
     this.sortableChildren = true;
   }
 
+  public getID(): number {
+    return this.id;
+  }
+
   public moveTo(pos: Pos) {
     this.x = pos.x;
     this.y = pos.y;
   }
 
-  public tryPlace(user: User) {
+  public tryPlace(user: User, spotID: number) {
     if (!this.spot.occupantID) {
       this.spot.occupantID = user.id;
       const np = {
@@ -54,7 +60,7 @@ export class BroadcastZone extends PIXI.Container implements IInteractable {
     }
   }
 
-  public tryUnplace(userID: string) {
+  public tryUnplace(userID: string, spotID: number = -1) {
     if (this.spot.occupantID === userID) {
       this.spot.occupantID = null;
     }

--- a/src/models/broadcastZone.ts
+++ b/src/models/broadcastZone.ts
@@ -49,7 +49,7 @@ export class BroadcastZone extends PIXI.Container implements IZone {
     this.y = pos.y;
   }
 
-  public tryPlace(user: User, spotID: number) {
+  public tryPlace(user: User, _: number) {
     if (!this.spot.occupantID) {
       this.spot.occupantID = user.id;
       const np = {
@@ -60,7 +60,7 @@ export class BroadcastZone extends PIXI.Container implements IZone {
     }
   }
 
-  public tryUnplace(userID: string, spotID: number = -1) {
+  public tryUnplace(userID: string, _: number = -1) {
     if (this.spot.occupantID === userID) {
       this.spot.occupantID = null;
     }

--- a/src/models/broadcastZone.ts
+++ b/src/models/broadcastZone.ts
@@ -11,10 +11,7 @@ const spotSize = standardTileSize;
 // BroadcastZone is a location from which any user
 // can broadcast to all other users in the world regardless
 // of proximity or zone.
-export class BroadcastZone
-  extends PIXI.Container
-  implements ICollider, IInteractable
-{
+export class BroadcastZone extends PIXI.Container implements IInteractable {
   id: number;
   name: string;
   physics: false;
@@ -79,14 +76,11 @@ export class BroadcastZone
   public tryInteract(other: User) {
     if (this.hits(other) && !this.spot.occupantID) {
       this.spot.occupantID = other.id;
-      other.media.enterBroadcast();
-      other.isInVicinity = false;
       other.updateZone(this.id);
       return;
     }
     if (other.id === this.spot.occupantID && !this.hits(other)) {
       this.spot.occupantID = null;
-      other.media.leaveBroadcast();
       other.updateZone(globalZoneID);
     }
   }

--- a/src/models/collider.ts
+++ b/src/models/collider.ts
@@ -1,14 +1,11 @@
 import * as PIXI from "pixi.js";
 import { Pos, Size } from "../worldTypes";
+import { Spot } from "./spot";
 import { User } from "./user";
 
 export interface ICollider {
   physics: boolean;
   hits: (other: ICollider) => boolean;
-}
-
-export interface IInteractable extends ICollider {
-  tryInteract: (user: User) => void;
 }
 
 // Collider is anything that can do a hit check

--- a/src/models/deskZone.ts
+++ b/src/models/deskZone.ts
@@ -26,8 +26,8 @@ export class DeskZone extends PIXI.Container implements IZone {
   constructor(id: number, name: string, numSpots: number, pos: Pos) {
     super();
 
-    if (this.id === 0) {
-      throw new Error("ID 0 is a reserved default zone ID");
+    if (id === globalZoneID) {
+      throw new Error(`ID ${id} is a reserved default zone ID`);
     }
     this.id = id;
     this.name = name;
@@ -139,6 +139,7 @@ export class DeskZone extends PIXI.Container implements IZone {
     let hadPriorSpot: boolean;
     let hasNewSpot: boolean;
     const oldFreeSeats = this.freeSeats;
+
     for (let spot of this.spots) {
       // If the user is already registered in this spot...
       if (spot.occupantID === user.id) {

--- a/src/models/deskZone.ts
+++ b/src/models/deskZone.ts
@@ -1,29 +1,25 @@
 import * as PIXI from "pixi.js";
 import { globalZoneID, standardTileSize } from "../config";
 import { Pos } from "../worldTypes";
-import { Collider, doesCollide, ICollider, IInteractable } from "./collider";
+import { Collider, doesCollide } from "./collider";
 import { Desk } from "./desk";
 import { Spot } from "./spot";
 import { User } from "./user";
+import { IZone } from "./zone";
 
 const spotSize = standardTileSize;
 const spotBuffer = 20;
 
 // DeskZone is a location that holds spots, through which a user can
 // join other users in an isolated zone.
-export class DeskZone
-  extends PIXI.Container
-  implements ICollider, IInteractable
-{
+export class DeskZone extends PIXI.Container implements IZone {
   physics = true;
-  id: number;
 
+  private id: number;
   private desk: Desk;
   private spots: Array<Spot> = [];
   private freeSeats: number;
-
-  staticBounds: PIXI.Rectangle;
-
+  private staticBounds: PIXI.Rectangle;
   private zoneMarker: PIXI.Graphics;
   private labelGraphics: PIXI.Text;
 
@@ -74,6 +70,10 @@ export class DeskZone
     this.createZoneMarker();
     this.createLabel();
     this.sortableChildren = true;
+  }
+
+  public getID(): number {
+    return this.id;
   }
 
   public getSpots(): Array<Spot> {

--- a/src/models/deskZone.ts
+++ b/src/models/deskZone.ts
@@ -143,13 +143,15 @@ export class DeskZone
       // If the user is already registered in this spot...
       if (spot.occupantID === user.id) {
         // ...and is still in the spot, do nothing
-        if (spot.hits(user)) return;
+        if (spot.hits(user) && !hasNewSpot) return;
         // User is no longer in the spot - clear the spot
         spot.occupantID = null;
         hadPriorSpot = true;
         continue;
       }
 
+      // If this spot has no occupant but the user
+      // hits it, occupy it.
       if (!spot.occupantID && spot.hits(user)) {
         spot.occupantID = user.id;
         user.updateZone(this.id, spot.id);
@@ -159,6 +161,8 @@ export class DeskZone
       }
     }
 
+    // If the user has just left a spot and has not
+    // joined a new one, go back to the global zone.
     if (hadPriorSpot && !hasNewSpot) {
       this.freeSeats++;
       user.updateZone(globalZoneID);
@@ -167,6 +171,7 @@ export class DeskZone
       this.freeSeats--;
     }
 
+    // Update the label text if needed.
     if (oldFreeSeats !== this.freeSeats) {
       this.updateLabel();
     }

--- a/src/models/robot.ts
+++ b/src/models/robot.ts
@@ -1,6 +1,6 @@
 import { rand } from "../util/math";
 import { Pos } from "../worldTypes";
-import { IInteractable } from "./collider";
+import { IZone } from "./zone";
 import { User } from "./user";
 
 export enum RobotRole {
@@ -49,10 +49,9 @@ export class Robot extends User {
     this.stepToTarget();
   }
 
-  // "Furniture" can be any non-user colliders in the world.
-  // Eg: desks or broadcast spots. This overrides the user
-  // furniture check.
-  checkFurnitures(others: Array<IInteractable>) {
+  // Focus zones include desks or broadcast spots.
+  // This overrides the user focus zone check.
+  checkFocusZones(others: Array<IZone>) {
     for (let other of others) {
       other.tryInteract(this);
     }

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -145,42 +145,65 @@ export class User extends Collider {
     const oldZoneID = this.zoneData.zoneID;
     const oldSpotID = this.zoneData.spotID;
 
+    // If the old zone is identical to this zone, there's
+    // nothing more to do - early out.
     if (zoneID === oldZoneID && spotID === oldSpotID) return;
 
+    // Update the user's zone data
     this.zoneData.zoneID = zoneID;
     this.zoneData.spotID = spotID;
 
+    // If the old zone was a broadcast zone, leave
+    // the broadcast. Otherwise if the new zone is
+    // a broadcast zone, enter the broadcast.
     if (oldZoneID === broadcastZoneID) {
       this.media.leaveBroadcast();
-    }
-
-    if (zoneID === broadcastZoneID) {
+    } else if (zoneID === broadcastZoneID) {
+      // If the user is already in another focus zone,
+      // leave that zone.
       if (this.media.currentAction === Action.InZone) {
         this.media.leaveZone();
       }
       this.alpha = maxAlpha;
       this.media.enterBroadcast();
+      this.isInVicinity = false;
     }
 
-    if (this.isLocal) {
-      if (oldZoneID !== globalZoneID) {
-        this.localZoneMates = {};
-      }
-      if (this.onJoinZone) this.onJoinZone({ zoneID: zoneID, spotID: spotID });
-      if (zoneID === globalZoneID) {
-        if (!this.media.cameraDisabled) {
-          this.setVideoTexture();
-        }
-        this.media.leaveZone();
-        return;
-      }
-      if (zoneID !== globalZoneID && zoneID !== broadcastZoneID) {
-        this.media.enterZone();
-      }
+    // If the new zone is not the global zone or broadcast zone,
+    // set the default sprite texture. We'll be showing video in
+    // separate, larger DOM elements.
+    if (zoneID !== globalZoneID && zoneID !== broadcastZoneID) {
       this.setDefaultTexture();
+    }
+
+    // The rest of the function is only relevant to the local user.
+    if (!this.isLocal) return;
+
+    // Reset the user's zonemates if they're not coming
+    // from the global zone.
+    if (oldZoneID !== globalZoneID) {
+      this.localZoneMates = {};
+    }
+    if (this.onJoinZone) {
+      this.onJoinZone({ zoneID: zoneID, spotID: spotID });
+    }
+    if (zoneID === globalZoneID) {
+      // If the local user's camera isn't disabled, set
+      // the video texture.
+      if (!this.media.cameraDisabled) {
+        this.setVideoTexture();
+      }
+      // Since their previous zone is not a global traversal zone,
+      // it must be a focus zone - leave it.
+      this.media.leaveZone();
       return;
     }
-    if (zoneID !== globalZoneID) this.setDefaultTexture();
+
+    // If the user is not in the global zone or the broadcast zone,
+    // they must be in an interactive focus zone - enter it.
+    if (zoneID !== globalZoneID && zoneID !== broadcastZoneID) {
+      this.media.enterZone();
+    }
   }
 
   getZoneData(): ZoneData {

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,12 +1,12 @@
-import { Collider, ICollider, IInteractable } from "./collider";
+import { Collider } from "./collider";
 import * as PIXI from "pixi.js";
 import { DisplayObject, MIPMAP_MODES } from "pixi.js";
-import { BroadcastZone } from "./broadcastZone";
 import { Action, UserMedia } from "./userMedia";
 import { Pos, Size, ZoneData } from "../worldTypes";
 import { Textures } from "../textures";
 import { broadcastZoneID, globalZoneID, standardTileSize } from "../config";
 import { clamp } from "../util/math";
+import { IZone } from "./zone";
 
 const minAlpha = 0.2;
 const inZoneAlpha = 0.5;
@@ -259,11 +259,10 @@ export class User extends Collider {
     }
   }
 
-  // "Furniture" can be any non-user colliders in the world.
-  // Eg: desks or broadcast spots
-  checkFurnitures(others: Array<IInteractable>) {
+  // "Focus zones" can be anything that implements IZone
+  checkFocusZones(others: Array<IZone>) {
     for (let other of others) {
-      this.checkFurniture(other);
+      other.tryInteract(this);
     }
   }
 
@@ -424,10 +423,6 @@ export class User extends Collider {
       o.media.muteAudio();
       return;
     }
-  }
-
-  private async checkFurniture(other: IInteractable) {
-    other.tryInteract(this);
   }
 
   private streamVideo(newTrack: MediaStreamTrack) {

--- a/src/models/zone.ts
+++ b/src/models/zone.ts
@@ -1,0 +1,9 @@
+import { ICollider } from "./collider";
+import { User } from "./user";
+
+export interface IZone extends ICollider {
+  tryInteract: (user: User) => void;
+  tryPlace: (user: User, spotID: number) => void;
+  tryUnplace: (userID: string, spotID: number) => void;
+  getID: () => number;
+}

--- a/src/world.ts
+++ b/src/world.ts
@@ -127,15 +127,15 @@ export class World {
     // communicated zone and spot as needed. "Placement" does not impact
     // user behavior itself (that is done via `user.updateZone()` above).
     // Placement affects zone spot occupation status and remote positioning.
-    for (let item of this.focusZones) {
-      if (oldZoneID === item.getID()) {
-        item.tryUnplace(user.id, oldSpotID);
+    for (let zone of this.focusZones) {
+      if (oldZoneID === zone.getID()) {
+        zone.tryUnplace(user.id, oldSpotID);
         // If the new zone is the global zone, don't bother
         // checking for any further placement.
         if (zoneID === globalZoneID) return;
       }
-      if (zoneID === item.getID()) {
-        item.tryPlace(user, spotID);
+      if (zoneID === zone.getID()) {
+        zone.tryPlace(user, spotID);
       }
     }
   }

--- a/src/world.ts
+++ b/src/world.ts
@@ -6,7 +6,7 @@ import { rand } from "./util/math";
 import Floor from "./models/floor";
 import { BroadcastZone } from "./models/broadcastZone";
 import { IAudioContext, AudioContext } from "standardized-audio-context";
-import { ICollider, IInteractable } from "./models/collider";
+import { IZone } from "./models/zone";
 import { Robot, RobotRole } from "./models/robot";
 import { Pos, ZoneData } from "./worldTypes";
 import { Textures } from "./textures";
@@ -33,10 +33,10 @@ export class World {
   private app: PIXI.Application = null;
   private worldContainer: PIXI.Container = null;
   private usersContainer: PIXI.Container = null;
-  private furnitureContainer: PIXI.Container = null;
+  private focusZonesContainer: PIXI.Container = null;
 
   private robots: Array<Robot> = [];
-  private furniture: Array<IInteractable> = [];
+  private focusZones: Array<IZone> = [];
 
   constructor() {
     const w = document.getElementById("world");
@@ -60,7 +60,7 @@ export class World {
     this.app.stage.addChild(frame);
 
     // Main world container, which will hold user
-    // and furniture containers.
+    // and focus zones containers.
     this.worldContainer = new PIXI.Container();
     this.worldContainer.width = defaultWorldSize;
     this.worldContainer.height = defaultWorldSize;
@@ -78,13 +78,13 @@ export class World {
     this.usersContainer.zIndex = 100;
     this.worldContainer.addChild(this.usersContainer);
 
-    // Container that will hold our room "furniture" elements,
+    // Container that will hold our room focus zone elements,
     // like broadcast spots
-    this.furnitureContainer = new PIXI.Container();
-    this.furnitureContainer.zIndex = 90;
-    this.furnitureContainer.width = this.worldContainer.width;
-    this.furnitureContainer.height = this.worldContainer.height;
-    this.worldContainer.addChild(this.furnitureContainer);
+    this.focusZonesContainer = new PIXI.Container();
+    this.focusZonesContainer.zIndex = 90;
+    this.focusZonesContainer.width = this.worldContainer.width;
+    this.focusZonesContainer.height = this.worldContainer.height;
+    this.worldContainer.addChild(this.focusZonesContainer);
 
     document.getElementById("world").appendChild(this.app.view);
   }
@@ -123,45 +123,19 @@ export class World {
       this.sendPosDataToParticipant(sessionID);
     }
 
-    let handledOldPlacement = false;
-    let handledNewPlacement = false;
-
-    // Iterate through all furniture and try to place/unplace user in
+    // Iterate through all focus zones and try to place/unplace user in
     // communicated zone and spot as needed. "Placement" does not impact
     // user behavior itself (that is done via `user.updateZone()` above).
     // Placement affects zone spot occupation status and remote positioning.
-    if (zoneID === broadcastZoneID) {
-      for (let item of this.furniture) {
-        if (item instanceof BroadcastZone) {
-          item.tryPlace(user);
-        }
+    for (let item of this.focusZones) {
+      if (oldZoneID === item.getID()) {
+        item.tryUnplace(user.id, oldSpotID);
+        // If the new zone is the global zone, don't bother
+        // checking for any further placement.
+        if (zoneID === globalZoneID) return;
       }
-    } else if (oldZoneID === broadcastZoneID) {
-      for (let item of this.furniture) {
-        if (item instanceof BroadcastZone) {
-          item.tryUnplace(user.id);
-        }
-      }
-    }
-
-    for (let item of this.furniture) {
-      if (item instanceof DeskZone) {
-        if (item.id === oldZoneID) {
-          item.tryUnplace(user.id, oldSpotID);
-          // If the remote user has moved to the global zone, just
-          // unplace them from previous zone and return
-          if (zoneID === globalZoneID) return;
-          handledOldPlacement = true;
-        }
-        if (
-          zoneID !== globalZoneID &&
-          !handledNewPlacement &&
-          item.id === zoneID
-        ) {
-          item.tryPlace(user, spotID);
-          if (handledOldPlacement || oldZoneID === globalZoneID) return;
-          handledNewPlacement = true;
-        }
+      if (zoneID === item.getID()) {
+        item.tryPlace(user, spotID);
       }
     }
   }
@@ -198,10 +172,10 @@ export class World {
     const user = this.createUser(sessionID, p.x, p.y, "You", true);
     // This will render the world and allow us to cross
     // check collision, to make sure the local user is not
-    // colliding with furniture.
+    // colliding with focus zones.
     this.app.render();
 
-    // Make sure we aren't colliding with any furniture,
+    // Make sure we aren't colliding with any focus zones,
     // reposition if so.
     this.getFinalLocalPos(user);
 
@@ -256,8 +230,8 @@ export class World {
       x: defaultWorldSize / 2 - zoneBroadcast.width / 2,
       y: zoneBroadcast.y,
     });
-    this.furnitureContainer.addChild(zoneBroadcast);
-    this.furniture.push(zoneBroadcast);
+    this.focusZonesContainer.addChild(zoneBroadcast);
+    this.focusZones.push(zoneBroadcast);
 
     // Create two desk zones
     const yPos = defaultWorldSize / 2 + 325;
@@ -266,13 +240,13 @@ export class World {
       x: defaultWorldSize / 2 - zone1.width - zoneBroadcast.width,
       y: zone1.y,
     });
-    this.furnitureContainer.addChild(zone1);
-    this.furniture.push(zone1);
+    this.focusZonesContainer.addChild(zone1);
+    this.focusZones.push(zone1);
 
     const zone2 = new DeskZone(2, "Kangaroo", 4, { x: 0, y: yPos });
     zone2.moveTo({ x: defaultWorldSize / 2 + zoneBroadcast.width, y: zone2.y });
-    this.furnitureContainer.addChild(zone2);
-    this.furniture.push(zone2);
+    this.focusZonesContainer.addChild(zone2);
+    this.focusZones.push(zone2);
   }
 
   createRobot(userID: string) {
@@ -298,7 +272,7 @@ export class World {
     if (!foundDesk) {
       role = RobotRole.Desk;
       // Find a desk position
-      for (let item of this.furnitureContainer.children) {
+      for (let item of this.focusZonesContainer.children) {
         if (item instanceof DeskZone) {
           const desk = <DeskZone>item;
 
@@ -312,7 +286,7 @@ export class World {
     if (!foundBroadcast) {
       role = RobotRole.Broadcast;
       // Find a broadcast position
-      for (let item of this.furnitureContainer.children) {
+      for (let item of this.focusZonesContainer.children) {
         if (item instanceof BroadcastZone) {
           const spot = <BroadcastZone>item;
           persistentPos = { x: spot.x, y: spot.y };
@@ -369,7 +343,7 @@ export class World {
   }
 
   private getFinalLocalPos(user: User): void {
-    for (let item of this.furniture) {
+    for (let item of this.focusZones) {
       let doesHit = false;
       if (item instanceof DeskZone) {
         const z = <DeskZone>item;
@@ -384,7 +358,7 @@ export class World {
       if (!doesHit) continue;
 
       console.log(
-        "User will hit furniture; finding new position:",
+        "User will hit focus zone; finding new position:",
         user.getPos()
       );
 
@@ -408,11 +382,11 @@ export class World {
     // Update all robots
     for (let robot of this.robots) {
       robot.update();
-      robot.checkFurnitures(this.furniture);
+      robot.checkFocusZones(this.focusZones);
     }
 
     this.localUser.processUsers(this.usersContainer.children);
-    this.localUser.checkFurnitures(this.furniture);
+    this.localUser.checkFocusZones(this.focusZones);
     this.checkNavigation(delta);
   }
 
@@ -472,11 +446,11 @@ export class World {
     // If the user moved, move them to the new coordinates.
     this.localUser.moveTo({ x: newX, y: newY });
 
-    // Iterate over all furniture and, if the new position
+    // Iterate over all focus zones and, if the new position
     // results in them colliding with an object that has
     // physics enabled, reset their pos to their previous
     // position and return.
-    for (let o of this.furniture) {
+    for (let o of this.focusZones) {
       if (o.physics && o.hits(this.localUser)) {
         this.localUser.moveTo(currentPos);
         return;
@@ -549,7 +523,7 @@ export class World {
   destroy() {
     Textures.destroy();
     this.localUser = null;
-    this.furniture = [];
+    this.focusZones = [];
     this.robots = [];
     this.app.destroy(true, true);
   }


### PR DESCRIPTION
This PR contains some tidy and refactoring for clarity while writing spatialization post 5. Specifically:

* Addresses an edge case where if a user moves between two spots in the _same_ zone, their spot ID is not consistently updated.
* Adds more clarifying comments
* Removes a couple of unneeded calls to `UserMedia` in `BroadcastZone.tryInteract()`, which are already handled in `user.updateZone()`
* Removes some unneeded imports
* Renames `IInteractable` to `IZone` and moves it into its own file
* Renames the somewhat ambiguous name of "furniture" to "focus zones" in `world.ts`, making it easier to grok and reason about in the content.

I hope this all makes sense, let me know if you have any questions or spot any weirdness!