### PR TITLE
Use `sendSettings` instead of `camSimulcastEncodings` and `setBandwidth()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@daily-co/daily-js": "^0.47.0",
+        "@daily-co/daily-js": "^0.48.0",
         "@pixi/unsafe-eval": "^7.2.4",
         "express": "^4.18.2",
         "http-server": "^14.0.0",
@@ -690,9 +690,9 @@
       }
     },
     "node_modules/@daily-co/daily-js": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.47.0.tgz",
-      "integrity": "sha512-9RtKtgSUiTd3mTqcvfsr6COYJWIKL7cDk8hmqeE6WW9eoWIBOx0PWGjt8QhvnLHsG8IPkbSYH8KQQPAm4pf99g==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.48.0.tgz",
+      "integrity": "sha512-NnBxHmxgztNbx3IFRP519H6bWdpm00UIq/8m2O1Zzc8ltcPI4FRvOSadjBTOmRPp275aMPBlrkqOGE/n9Pl8Uw==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "bowser": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Liza Shulyayeva",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@daily-co/daily-js": "^0.47.0",
+    "@daily-co/daily-js": "^0.48.0",
     "@pixi/unsafe-eval": "^7.2.4",
     "express": "^4.18.2",
     "http-server": "^14.0.0",

--- a/src/room.ts
+++ b/src/room.ts
@@ -77,7 +77,7 @@ export default class Room {
     this.callObject = DailyIframe.createCallObject({
       subscribeToTracksAutomatically: false,
       sendSettings: {
-        vieo: {
+        video: {
           // This is a temporary workaround until medium and high encodings become
           // optional in the next `daily-js` release:
           // @ts-ignore

--- a/src/room.ts
+++ b/src/room.ts
@@ -78,9 +78,31 @@ export default class Room {
     this.isGlobal = isGlobal;
     this.callObject = DailyIframe.createCallObject({
       subscribeToTracksAutomatically: false,
+      sendSettings: {
+        vieo: {
+          encodings: {
+            low: {
+              maxBitrate: 75000,
+              scaleResolutionDownBy: 4,
+              maxFramerate: 25,
+            },
+            medium: {
+              maxBitrate: 300000,
+              scaleResolutionDownBy: 2,
+              maxFramerate: 30,
+            },
+            // This is a temporary workaround until medium and high encodings become
+            // optional in the next `daily-js` release:
+            high: null,
+          },
+        },
+      },
       dailyConfig: {
-        camSimulcastEncodings: [{ maxBitrate: 600000, maxFramerate: 30 }],
         avoidEval: true,
+        userMediaVideoConstraints: {
+          width: 400,
+          height: 400,
+        },
       },
     })
       .on("camera-error", (e) => this.handleCameraError(e))
@@ -124,21 +146,17 @@ export default class Room {
     switch (level) {
       case BandwidthLevel.Tile:
         this.localBandwidthLevel = level;
-        this.callObject.setBandwidth({
-          trackConstraints: {
-            width: standardTileSize,
-            height: standardTileSize,
-            frameRate: 15,
+        this.callObject.updateSendSettings({
+          video: {
+            maxQuality: "low",
           },
         });
         break;
       case BandwidthLevel.Focus:
         this.localBandwidthLevel = level;
-        this.callObject.setBandwidth({
-          trackConstraints: {
-            width: 200,
-            height: 200,
-            frameRate: 30,
+        this.callObject.updateSendSettings({
+          video: {
+            maxQuality: "medium",
           },
         });
         break;

--- a/src/room.ts
+++ b/src/room.ts
@@ -112,7 +112,7 @@ export default class Room {
       .on("app-message", (e) => this.handleAppMessage(e))
       .on("network-connection", (e) => this.handleNetworkConnectionChanged(e));
 
-    this.setBandwidth(BandwidthLevel.Tile);
+    this.setVideoQuality(BandwidthLevel.Tile);
   }
 
   async join() {
@@ -140,7 +140,7 @@ export default class Room {
     delete this.pendingAcks[sessionID];
   }
 
-  private setBandwidth(level: BandwidthLevel) {
+  private setVideoQuality(level: BandwidthLevel) {
     switch (level) {
       case BandwidthLevel.Tile:
         this.callObject.updateSendSettings({
@@ -158,7 +158,7 @@ export default class Room {
         break;
       default:
         console.warn(
-          `setBandwidth called with unrecognized level (${level}). Not modifying any constraints.`,
+          `setVideoQuality() called with unrecognized level (${level}). This is a no-op.`,
         );
     }
   }
@@ -179,11 +179,11 @@ export default class Room {
   }
 
   private handleCameraError(event: DailyEventObjectCameraError) {
-    console.error(`camera error in room ${this.url}": ${event}`);
+    console.error(`camera error in room ${this.url}`, event);
   }
 
   private handleError(event: DailyEventObjectFatalError) {
-    console.error(`error in room ${this.url}": ${event}`);
+    console.error(`error in room ${this.url}`, event);
   }
 
   private handleJoinedMeeting(event: DailyEventObjectParticipants) {
@@ -247,13 +247,13 @@ export default class Room {
     // to other participants.
     const onJoinZone = (zoneData: ZoneData, recipient: string = "*") => {
       if (zoneData.zoneID === globalZoneID) {
-        this.setBandwidth(BandwidthLevel.Tile);
+        this.setVideoQuality(BandwidthLevel.Tile);
         if (this.localState.screen) {
           this.stopScreenShare();
         }
         enableScreenBtn(false);
       } else {
-        this.setBandwidth(BandwidthLevel.Focus);
+        this.setVideoQuality(BandwidthLevel.Focus);
         enableScreenBtn(true);
       }
       const data = {

--- a/src/room.ts
+++ b/src/room.ts
@@ -80,6 +80,9 @@ export default class Room {
       subscribeToTracksAutomatically: false,
       sendSettings: {
         vieo: {
+          // This is a temporary workaround until medium and high encodings become
+          // optional in the next `daily-js` release:
+          // @ts-ignore
           encodings: {
             low: {
               maxBitrate: 75000,
@@ -91,9 +94,6 @@ export default class Room {
               scaleResolutionDownBy: 2,
               maxFramerate: 30,
             },
-            // This is a temporary workaround until medium and high encodings become
-            // optional in the next `daily-js` release:
-            high: null,
           },
         },
       },

--- a/src/room.ts
+++ b/src/room.ts
@@ -10,7 +10,7 @@ import DailyIframe, {
   DailyRoomInfo,
   DailyEventObjectParticipantLeft,
 } from "@daily-co/daily-js";
-import { globalZoneID, standardTileSize } from "./config";
+import { globalZoneID } from "./config";
 
 import {
   enableScreenBtn,

--- a/src/room.ts
+++ b/src/room.ts
@@ -87,7 +87,7 @@ export default class Room {
             low: {
               maxBitrate: 75000,
               scaleResolutionDownBy: 4,
-              maxFramerate: 25,
+              maxFramerate: 15,
             },
             medium: {
               maxBitrate: 300000,

--- a/src/room.ts
+++ b/src/room.ts
@@ -78,9 +78,6 @@ export default class Room {
       subscribeToTracksAutomatically: false,
       sendSettings: {
         video: {
-          // This is a temporary workaround until medium and high encodings become
-          // optional in the next `daily-js` release:
-          // @ts-ignore
           encodings: {
             low: {
               maxBitrate: 75000,

--- a/src/room.ts
+++ b/src/room.ts
@@ -66,8 +66,6 @@ export default class Room {
 
   pendingAcks: { [key: string]: ReturnType<typeof setInterval> } = {};
 
-  localBandwidthLevel = BandwidthLevel.Unknown;
-
   localState: State = { audio: null, video: null };
 
   topology: Topology;
@@ -145,7 +143,6 @@ export default class Room {
   private setBandwidth(level: BandwidthLevel) {
     switch (level) {
       case BandwidthLevel.Tile:
-        this.localBandwidthLevel = level;
         this.callObject.updateSendSettings({
           video: {
             maxQuality: "low",
@@ -153,7 +150,6 @@ export default class Room {
         });
         break;
       case BandwidthLevel.Focus:
-        this.localBandwidthLevel = level;
         this.callObject.updateSendSettings({
           video: {
             maxQuality: "medium",


### PR DESCRIPTION
This PR removes the usage of `camSimuclastEncodings` and `setBandwidth()` in favor of the new `sendSettings` property and `updateSendSettings()` instance method. It also utilizes `userMediaVideoConstraints` to set starting video dimensions (which will be downscaled to desired dimensions by the defined simulcast layers). 